### PR TITLE
feature: Update TSONContext content retriever

### DIFF
--- a/src/main/java/com/euph28/tson/assertionengine/keyword/assertion/AssertionBase.java
+++ b/src/main/java/com/euph28/tson/assertionengine/keyword/assertion/AssertionBase.java
@@ -2,7 +2,6 @@ package com.euph28.tson.assertionengine.keyword.assertion;
 
 import com.euph28.tson.assertionengine.TSONAssertionEngine;
 import com.euph28.tson.context.TSONContext;
-import com.euph28.tson.context.provider.JsonValueProvider;
 import com.euph28.tson.core.keyword.Keyword;
 import com.euph28.tson.core.keyword.KeywordType;
 import com.euph28.tson.interpreter.Statement;
@@ -91,8 +90,7 @@ public abstract class AssertionBase extends Keyword {
      * @return Map of path-to-value of resolved values. Returns {@code null} if path was invalid
      */
     protected Map<String, String> getValueFromJson(TSONContext tsonContext, String jsonPath) {
-        JsonValueProvider jsonValueProvider = new JsonValueProvider();
-        return jsonValueProvider.getValuesFromJson(tsonContext, jsonPath);
+        return tsonContext.getContent(jsonPath.startsWith("json.") ? jsonPath : "json." + jsonPath);
     }
 
     /* ----- METHODS ------------------------------ */

--- a/src/main/java/com/euph28/tson/assertionengine/keyword/assertion/PathValueAssertion.java
+++ b/src/main/java/com/euph28/tson/assertionengine/keyword/assertion/PathValueAssertion.java
@@ -160,7 +160,7 @@ public abstract class PathValueAssertion extends AssertionBase {
                 path = getPathFromExpression(splitValues);
             } catch (ArrayIndexOutOfBoundsException e) {
                 LoggerFactory.getLogger(this.getClass()).error("Failed to retrieve path from expression array: " + Arrays.toString(splitValues), e);
-                resultFail("Failed to retrieve path for expression: " + entry, "Failed to assert expression", entry);
+                resultFail("Failed to retrieve path for expression: " + entry, getStepDescription(splitValues), entry);
                 continue;
             }
 
@@ -169,13 +169,20 @@ public abstract class PathValueAssertion extends AssertionBase {
             // Error handling: Checking if values failed to be resolved
             if (actualValue == null) {
                 // TODO: Wrap this in another(?) try-catch
-                resultFail("Failed to retrieve values for JSON path: " + path, "Failed to assert expression", entry);
+                resultFail("Failed to retrieve values for JSON path: " + path, getStepDescription(splitValues), entry);
                 continue;
             }
 
             /* ===== VERIFY: NORMAL vs COUNT ===== */
             switch (splitValues.length) {
                 case 2: // Default setup, eg: path=value. Perform assertion individually for each value
+                    // Error checking: Report failure if there were no actual values (doesn't make sense for asserting nothing)
+                    if (actualValue.isEmpty()) {
+                        resultFail("Failed to retrieve any value for JSON path: " + path,
+                                getStepDescription(splitValues),
+                                entry
+                        );
+                    }
                     for (String key : actualValue.keySet()) {
                         // Wrap in try/catch in case expression is accessed without handling array index
                         try {

--- a/src/main/java/com/euph28/tson/context/keyword/RequestVariable.java
+++ b/src/main/java/com/euph28/tson/context/keyword/RequestVariable.java
@@ -66,7 +66,7 @@ public class RequestVariable extends Keyword {
             }
 
             // Retrieve JSON path
-            String pathValue = tsonContext.getContent("json.request." + splitValues[1]);
+            String pathValue = tsonContext.getContent("json.request." + splitValues[1], false);
 
             // Error check: invalid value
             if (pathValue.isEmpty()) {

--- a/src/main/java/com/euph28/tson/context/keyword/ResponseVariable.java
+++ b/src/main/java/com/euph28/tson/context/keyword/ResponseVariable.java
@@ -5,9 +5,9 @@ import com.euph28.tson.context.VariableType;
 import com.euph28.tson.core.keyword.Keyword;
 import com.euph28.tson.core.keyword.KeywordType;
 import com.euph28.tson.interpreter.Statement;
+import com.euph28.tson.reporter.TSONReporter;
 import com.euph28.tson.reporter.report.Report;
 import com.euph28.tson.reporter.report.ReportType;
-import com.euph28.tson.reporter.TSONReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,7 +66,7 @@ public class ResponseVariable extends Keyword {
             }
 
             // Retrieve JSON path
-            String pathValue = tsonContext.getContent("json." + splitValues[1]);
+            String pathValue = tsonContext.getContent("json." + splitValues[1], false);
 
             // Error check: invalid value
             if (pathValue.isEmpty()) {

--- a/src/main/java/com/euph28/tson/context/provider/ContentProvider.java
+++ b/src/main/java/com/euph28/tson/context/provider/ContentProvider.java
@@ -2,6 +2,8 @@ package com.euph28.tson.context.provider;
 
 import com.euph28.tson.context.TSONContext;
 
+import java.util.Map;
+
 /**
  * Base class for providing content based on a String
  * Provides a way to inject values into value Strings used in other classes
@@ -16,11 +18,11 @@ public interface ContentProvider {
     String getPrefix();
 
     /**
-     * Retrieve the substitute content for the provided key
+     * Retrieve the content for the provided key
      *
      * @param tsonContext TSON context that called for this provider
      * @param key         Key for the content to be retrieved
-     * @return Content that should replace the key. This should return an empty String if key is invalid
+     * @return Map of path to content. This should return an empty map if nothing was found
      */
-    String getContent(TSONContext tsonContext, String key);
+    Map<String, String> getContent(TSONContext tsonContext, String key);
 }

--- a/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
+++ b/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
@@ -187,7 +187,7 @@ public class JsonValueProvider implements ContentProvider {
     }
 
     @Override
-    public String getContent(TSONContext tsonContext, String key) {
-        return getValueFromJson(tsonContext, key);
+    public Map<String, String> getContent(TSONContext tsonContext, String key) {
+        return getValuesFromJson(tsonContext, key);
     }
 }

--- a/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
+++ b/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
@@ -8,7 +8,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -73,50 +75,58 @@ public class JsonValueProvider implements ContentProvider {
         String jsonContent = getJsonContent(tsonContext, jsonPath);
         jsonPath = updatePath(jsonPath);
 
-        // Retrieve value from jsonPath
-        ObjectMapper objectMapper = new ObjectMapper();
-        Map<String, JsonNode> nodeMap = new LinkedHashMap<>();
+        // Setup required variables
+        ObjectMapper objectMapper = new ObjectMapper();             // JSON library mapper
+        Map<String, JsonNode> nodeMap = new LinkedHashMap<>();      // Map of path-to-nodes that will be returned. This is traversed until path is resolved
+        String[] jsonPathSplit = jsonPath.split("/");         // List of paths to traverse
+
+        // Retrieve the first node
         try {
             // Initial node
             nodeMap.put("", objectMapper.readTree(jsonContent));
-
-            // Generate list of path to traverse
-            String[] jsonPathSplit = jsonPath.split("/");
-
-            // Traverse each path and update node
-            for (String path : jsonPathSplit) {
-                // Skip if empty (needed for first index due to path starting with "/", keeping it in case of human error)
-                if(path.isEmpty()) {
-                    continue;
-                }
-
-                // Updated node map, will replace the original at end of each iteration
-                Map<String, JsonNode> updatedNodeMap = new LinkedHashMap<>();
-
-                // Traverse each node to traverse each path (handles splitting when wildcard is present)
-                for (String nodeMapKey : nodeMap.keySet()) {
-                    JsonNode node = nodeMap.get(nodeMapKey);
-
-                    if (path.equals("*") && node.isArray()) {   // Scenario: Split into individual elements in array if wildcard is used
-                        for (int i = 0; i < node.size(); i++) {
-                            updatedNodeMap.put(nodeMapKey + "/" + i, node.get(i));
-                        }
-                    } else {                                    // Scenario: Default scenario to just take direct value
-                        updatedNodeMap.put(
-                                nodeMapKey + "/" + path,
-                                path.matches("-?\\d+") ? node.get(Integer.parseInt(path)) : node.get(path)
-                        );
-                    }
-                }
-
-                nodeMap = updatedNodeMap;
-            }
         } catch (JsonProcessingException e) {
             logger.error("Failed to process provided JSON for path: " + originalPath, e);
-            return null;
-        } catch (NullPointerException e) {
-            logger.error(String.format("Failed to resolve pointer path \"%s\", provided by JSON path \"%s\"", jsonPath, originalPath), e);
-            return null;
+            return new LinkedHashMap<>();
+        }
+
+        // Traverse each path and update node
+        for (String path : jsonPathSplit) {
+            // Skip if empty (needed for first index due to path starting with "/", keeping it in case of human error)
+            if (path.isEmpty()) {
+                continue;
+            }
+
+            // Temporary updated node map for this iteration, will replace the original at end of each iteration
+            Map<String, JsonNode> iterationNodeMap = new LinkedHashMap<>();
+
+            // Traverse each node to traverse each path (handles splitting when wildcard is present)
+            for (String nodeMapKey : nodeMap.keySet()) {
+                JsonNode currentNode = nodeMap.get(nodeMapKey);
+
+                // Part 1: Generate new list of paths for this node (if it splits)
+                List<String> currentNodePathList = new ArrayList<>();
+                if (path.equals("*") && currentNode.isArray()) {    // Generate new node paths if this is an array and wildcard is used
+                    for (int i = 0; i < currentNode.size(); i++) {
+                        currentNodePathList.add(String.valueOf(i));
+                    }
+                } else {
+                    currentNodePathList.add(path);
+                }
+
+                // Part 2: Retrieve the new nodes based on the new list of paths
+                for (String currentNodePath : currentNodePathList) {
+                    JsonNode value = currentNodePath.matches("-?\\d+") ? currentNode.get(Integer.parseInt(currentNodePath)) : currentNode.get(currentNodePath);
+                    if (value != null) {
+                        // Only add if value is not null
+                        iterationNodeMap.put(nodeMapKey + "/" + currentNodePath, value);
+                    } else {
+                        // Otherwise, log a warning
+                        logger.warn(String.format("Null value found when resolving pointer path \"%s\", provided by JSON path \"%s\"", nodeMapKey + "/" + currentNodePath, originalPath));
+                    }
+                }
+            }
+
+            nodeMap = iterationNodeMap;
         }
 
         // Post-processing: Convert from node to path-value map
@@ -129,7 +139,7 @@ public class JsonValueProvider implements ContentProvider {
                 );
             } catch (NullPointerException e) {
                 logger.error(String.format("Failed to resolve pointer path \"%s\", provided by JSON path \"%s\"", jsonPath, originalPath), e);
-                return null;
+                return new LinkedHashMap<>();
             }
         }
 

--- a/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
+++ b/src/main/java/com/euph28/tson/context/provider/JsonValueProvider.java
@@ -67,7 +67,7 @@ public class JsonValueProvider implements ContentProvider {
      *                    Otherwise, response data will be used instead
      * @return Map of path-to-value of resolved values. Returns {@code null} if path was invalid
      */
-    public Map<String, String> getValuesFromJson(TSONContext tsonContext, String jsonPath) {
+    Map<String, String> getValuesFromJson(TSONContext tsonContext, String jsonPath) {
         // Store original path for logging
         String originalPath = jsonPath;
 
@@ -121,7 +121,7 @@ public class JsonValueProvider implements ContentProvider {
                         iterationNodeMap.put(nodeMapKey + "/" + currentNodePath, value);
                     } else {
                         // Otherwise, log a warning
-                        logger.warn(String.format("Null value found when resolving pointer path \"%s\", provided by JSON path \"%s\"", nodeMapKey + "/" + currentNodePath, originalPath));
+                        logger.error(String.format("Null value found when resolving pointer path \"%s\", provided by JSON path \"%s\"", nodeMapKey + "/" + currentNodePath, originalPath));
                     }
                 }
             }
@@ -156,8 +156,9 @@ public class JsonValueProvider implements ContentProvider {
      *                    Starting the jsonPath with "{@code request.}" will result in request JSON being used.
      *                    Otherwise, response data will be used instead
      * @return Value located at path. Returns an empty String if path is invalid
+     * @deprecated Use {@link #getValuesFromJson(TSONContext, String)} instead
      */
-    public String getValueFromJson(TSONContext tsonContext, String jsonPath) {
+    String getValueFromJson(TSONContext tsonContext, String jsonPath) {
         // Store original path for logging
         String originalPath = jsonPath;
 

--- a/src/main/java/com/euph28/tson/context/provider/StringMapProvider.java
+++ b/src/main/java/com/euph28/tson/context/provider/StringMapProvider.java
@@ -55,7 +55,13 @@ public class StringMapProvider implements ContentProvider {
     }
 
     @Override
-    public String getContent(TSONContext tsonContext, String key) {
-        return dataMap.getOrDefault(key, "");
+    public Map<String, String> getContent(TSONContext tsonContext, String key) {
+        Map<String, String> result = new HashMap<>();
+
+        if (dataMap.containsKey(key)) {
+            result.put(key, dataMap.get(key));
+        }
+
+        return result;
     }
 }

--- a/src/main/java/com/euph28/tson/restclientinterface/TSONRestClient.java
+++ b/src/main/java/com/euph28/tson/restclientinterface/TSONRestClient.java
@@ -110,10 +110,10 @@ public class TSONRestClient implements KeywordProvider {
      */
     public void send() {
         // Retrieve values from property
-        String requestUrl = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_URL);
-        String requestPort = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_PORT);
-        String requestRoute = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_ROUTE);
-        String requestVerb = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_VERB);
+        String requestUrl = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_URL, false);
+        String requestPort = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_PORT, false);
+        String requestRoute = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_ROUTE, false);
+        String requestVerb = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_VERB, false);
 
         // Connection
         HttpURLConnection connection;
@@ -284,7 +284,7 @@ public class TSONRestClient implements KeywordProvider {
      * @param useContentProvider Specifies if the {@code requestBody} should be sent to the {@link ContentProvider} to be resolved
      */
     public void setRequestBody(String requestBody, boolean useContentProvider) {
-        String requestBodyPrefix = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_BODY_PREFIX);
+        String requestBodyPrefix = tsonContext.getContent(VariableType.PROPERTY.getPrefix() + "." + PROPERTY_REQUEST_BODY_PREFIX, false);
 
         if (useContentProvider) {
             setRequestBody(contentProvider.getContent(requestBodyPrefix + requestBody));


### PR DESCRIPTION
# Summary
Change TSONContext to return multiple values. This was an issue where some providers such as properties and variables always return one value per key but providers such as JSON where wildcards were acceptable would return multiple per key.

## TSONContext
- Allow TSONContext & ContentProvider to return multiple values per key (this is now default)
- Allow resolving without a prefix (this is used only if there is no result from using a prefix)
- Update inheriting classes and callers to use the new change

## JSONValueProvider
- Refactor JSON value retrieval to attempt to look cleaner (reduce code repetition)
- Change error returns to return an empty result instead of null
- Change error catching to no longer catch NPE but instead avoid storing/using null values directly
- Hide methods for retrieving values. Use the ContentProvider methods instead

## Assertion
- Remove direct use of JSONValueProvider in AssertionBase
- Add extra assertion that fails the test if no JSON value was found when doing normal assertion (actual to expected value assertion)