### PR TITLE
fix: Open access to TSONInterpreter from TSONRunner

### DIFF
--- a/src/main/java/com/euph28/tson/interpreter/TSONInterpreter.java
+++ b/src/main/java/com/euph28/tson/interpreter/TSONInterpreter.java
@@ -131,7 +131,7 @@ public class TSONInterpreter {
      *
      * @return List of {@link Keyword} provided
      */
-    List<Keyword> getKeywords() {
+    public List<Keyword> getKeywords() {
         return keywordProviderList
                 .stream()
                 .flatMap(provider -> provider.getKeywordList().stream())

--- a/src/main/java/com/euph28/tson/runner/TSONRunner.java
+++ b/src/main/java/com/euph28/tson/runner/TSONRunner.java
@@ -239,4 +239,9 @@ public class TSONRunner {
         // Output result
         return tsonReporter;
     }
+
+    /* ----- GETTERS ------------------------------ */
+    public TSONInterpreter getTsonInterpreter() {
+        return tsonInterpreter;
+    }
 }


### PR DESCRIPTION
- Change TSONInterpreter::getKeywords to be public
- Add TSONRunner::getTsonInterpreter for LSP to be able to get the current Intepreter

+semver: patch