### PR TITLE
fix: Create default request/response result in TSONRestClient

### DIFF
--- a/src/main/java/com/euph28/tson/restclientinterface/TSONRestClient.java
+++ b/src/main/java/com/euph28/tson/restclientinterface/TSONRestClient.java
@@ -124,6 +124,14 @@ public class TSONRestClient implements KeywordProvider {
                 + (requestRoute.startsWith("/") ? "" : "/")
                 + requestRoute;
 
+        // Default request/response (in case of error)
+        requestData = new RequestData(urlString, requestBody);
+        responseData = new ResponseData(
+                -1,
+                "",
+                0
+        );
+
         // Setup request
         try {
             // Create connection objects


### PR DESCRIPTION
- TSONRestClient will now store an empty request/response data when sending a new request. This should avoid previous data from being carried forward if an error was faced