### PR TITLE
Added time tracking to the Rest Client

### DIFF
--- a/src/main/java/com/euph28/tson/context/restdata/ResponseData.java
+++ b/src/main/java/com/euph28/tson/context/restdata/ResponseData.java
@@ -17,23 +17,51 @@ public class ResponseData {
     String responseBody;
 
     /**
-     * Response duration in nanoseconds
+     * Time that connection started
      */
-    int responseDuration;
+    long timeStart;
+
+    /**
+     * Time that connection was successful
+     */
+    long timeConnect;
+
+    /**
+     * Time that the response started to be received
+     */
+    long timeResponse;
+
+    /**
+     * Time that connection ended
+     */
+    long timeEnd;
 
     /* ----- CONSTRUCTOR ------------------------------ */
 
     /**
+     * Empty response data
+     */
+    public ResponseData() {
+        this(0, "", 0, 0, 0, 0);
+    }
+
+    /**
      * Data related to response received from server
      *
-     * @param responseStatus   Status code of the response
-     * @param responseBody     Content body of the response
-     * @param responseDuration Response duration in nanoseconds
+     * @param responseStatus Status code of the response
+     * @param responseBody   Content body of the response
+     * @param timeStart      Time connection started in nanoseconds
+     * @param timeConnect    Time connection was successful in nanoseconds
+     * @param timeResponse   Time initial response received in nanoseconds
+     * @param timeEnd        Time connection ended in nanoseconds
      */
-    public ResponseData(int responseStatus, String responseBody, int responseDuration) {
+    public ResponseData(int responseStatus, String responseBody, long timeStart, long timeConnect, long timeResponse, long timeEnd) {
         this.responseStatus = responseStatus;
         this.responseBody = responseBody;
-        this.responseDuration = responseDuration;
+        this.timeStart = timeStart;
+        this.timeConnect = timeConnect;
+        this.timeResponse = timeResponse;
+        this.timeEnd = timeEnd;
     }
 
     /* ----- SETTERS & GETTERS ------------------------------ */
@@ -57,11 +85,38 @@ public class ResponseData {
     }
 
     /**
-     * Retrieve the duration for the response
+     * Retrieve the time connection started
      *
-     * @return Response duration in nanoseconds
+     * @return Time connection started in nanoseconds
      */
-    public int getResponseDuration() {
-        return responseDuration;
+    public long getTimeStart() {
+        return timeStart;
+    }
+
+    /**
+     * Retrieve the time connection was successful
+     *
+     * @return Time connection was successful in nanoseconds
+     */
+    public long getTimeConnect() {
+        return timeConnect;
+    }
+
+    /**
+     * Retrieve the time initial response was received
+     *
+     * @return Time initial response received in nanoseconds
+     */
+    public long getTimeResponse() {
+        return timeResponse;
+    }
+
+    /**
+     * Retrieve the time connection ended
+     *
+     * @return Time connection ended in nanoseconds
+     */
+    public long getTimeEnd() {
+        return timeEnd;
     }
 }

--- a/src/main/java/com/euph28/tson/interpreter/Interpretation.java
+++ b/src/main/java/com/euph28/tson/interpreter/Interpretation.java
@@ -65,10 +65,8 @@ public class Interpretation {
         String regex = "(?=\\b(" + String.join("|", keywordCodeList) + ")\\b)";
 
         /* 2. Pre-processing    : Remove comments */
-        /* 2.1 Remove multi-line comments */
-        content = content.replaceAll("/\\*.*?(?:\\*/|\\z)", "");
-        /* 2.2 Remove single-line comments */
-        content = content.replaceAll("//.*?(?:[\\n\\r]|\\z)", "");
+        /* 2 Remove multi-line and single comments (using an OR of both scenarios) */
+        content = content.replaceAll("(?://.*?(?:[\\n\\r]|\\z))|(?:/\\*.*?(?:\\*/|\\z))", "");
 
         /*
          * 3. Parsing           : Split from one long String into a list of Strings,

--- a/src/main/java/com/euph28/tson/restclientinterface/keyword/KeywordSend.java
+++ b/src/main/java/com/euph28/tson/restclientinterface/keyword/KeywordSend.java
@@ -55,6 +55,10 @@ public class KeywordSend extends KeywordBase {
         report.setReportStep(String.format("Send %s to %s", statement.getValue(), tsonRestClient.getRequestData().getRequestUrl()));
         report.addAttachment("request.json", tsonRestClient.getRequestData().getRequestBody());
         report.addAttachment("response.json", tsonRestClient.getResponseData().getResponseBody());
+        report.addAttachment("time_start", String.valueOf(tsonRestClient.getResponseData().getTimeStart()));
+        report.addAttachment("time_connect", String.valueOf(tsonRestClient.getResponseData().getTimeConnect()));
+        report.addAttachment("time_response", String.valueOf(tsonRestClient.getResponseData().getTimeResponse()));
+        report.addAttachment("time_end", String.valueOf(tsonRestClient.getResponseData().getTimeEnd()));
         return true;
     }
 }


### PR DESCRIPTION
### Rest Client
- Tracks the following time
    - `time_start`: Start of connection
    - `time_connect`: Connection established
    - `time_response`: Initial response read
    - `time_end`: End of connection
- All values are added as attachment in reporter of KeywordSend with the keys above

### Others
- Interpreter: Changed regex of comments 